### PR TITLE
Use semver tag to create project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ was inspired by the [Drupal project](https://github.com/drupal-composer/drupal-p
 Create an Iceberg project:
 
 ```php
-composer create-project isovera/iceberg:8.x-dev /path/to/project
+composer create-project isovera/iceberg:0.1 /path/to/project
 ```


### PR DESCRIPTION
Using `8.x-dev` with `create-project` results in the following error:

```sh
  [InvalidArgumentException]                                    
  Could not find package isovera/iceberg with version 8.x-dev.  
```

I added a tag `0.1` following basic semver syntax and that installed OK.
https://getcomposer.org/doc/articles/versions.md#tags

Looks like `8.x-dev` would refer to a branch named `8` but I couldn't get that to work.
https://getcomposer.org/doc/articles/versions.md#branches